### PR TITLE
🔨 Add Cloudflare Pages docs deploy (parallel to RtD)

### DIFF
--- a/.github/workflows/deploy-docs-cf.yml
+++ b/.github/workflows/deploy-docs-cf.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build docs
         run: uv run zensical build --clean
 
+      - name: Add _worker.js (path router for subprojects)
+        run: cp _worker.js site/_worker.js
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/deploy-docs-cf.yml
+++ b/.github/workflows/deploy-docs-cf.yml
@@ -1,0 +1,49 @@
+name: Deploy docs to Cloudflare Pages
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-docs-cf-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Override site_url for the Cloudflare build
+        run: |
+          sed -i 's|^site_url = .*|site_url = "https://owid-docs.pages.dev/"|' zensical.toml
+
+      - name: Build docs
+        run: uv run zensical build --clean
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy site
+            --project-name=owid-docs
+            --branch=${{ github.head_ref || github.ref_name }}

--- a/_worker.js
+++ b/_worker.js
@@ -1,0 +1,32 @@
+// Cloudflare Pages Functions worker for the owid-docs project.
+//
+// When present at the deployment root, this file intercepts ALL requests
+// for this Pages project. We use it as a thin router so that one custom
+// domain (docs-cf.owid.io and later docs.owid.io) can transparently serve
+// docs from multiple source repos:
+//
+//   /projects/etl/*   →  proxied to https://owid-etl-docs.pages.dev/projects/etl/*
+//   everything else   →  served from this project's own static assets
+//
+// Each subproject keeps its own GitHub repo, its own CI, and its own
+// Pages project (per-PR previews on *.pages.dev still work as today).
+// Add a new route here whenever another subproject migrates to CF Pages.
+
+const SUBPROJECTS = {
+  "/projects/etl/": "https://owid-etl-docs.pages.dev",
+};
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    for (const [prefix, origin] of Object.entries(SUBPROJECTS)) {
+      if (url.pathname.startsWith(prefix)) {
+        const target = `${origin}${url.pathname}${url.search}`;
+        return fetch(target, request);
+      }
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Stands up a **parallel** Cloudflare Pages deploy of the umbrella docs at `owid-docs.pages.dev`, alongside the existing RtD and GitHub Pages builds (both untouched). Mirrors the pattern just landed in [`owid/etl`](https://github.com/owid/etl/pull/6148) for the ETL subproject.

| | |
|---|---|
| Workflow | `.github/workflows/deploy-docs-cf.yml` |
| CF project | `owid-docs` (Direct Upload, production branch = `main`) |
| Staging URL | `https://owid-docs.pages.dev/` |
| RtD | unchanged — `.readthedocs.yml`, `zensical.toml`, `docs/` all untouched |
| GH Pages | unchanged — existing `docs.yml` workflow continues |

### Before merging — manual setup

1. Create the CF Pages project via CLI (the dashboard's "Upload static files" flow now creates a Worker, not a Pages project):
   ```bash
   npx wrangler pages project create owid-docs --production-branch=main
   ```
2. Add the same secrets used in the etl repo: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`. Settings → Secrets and variables → Actions → New repository secret.
3. After first successful deploy, no custom-domain attachment yet — that's deferred until the cut-over plan is in place (see below).

### Cut-over architecture (out of scope here)

`docs-cf.owid.io` is currently bound to the `owid-etl-docs` project for `/projects/etl/`. Two Pages projects can't share one custom domain, so unifying them under one URL needs a small CF Worker that routes:

- `docs-cf.owid.io/projects/etl/*` → `owid-etl-docs.pages.dev`
- everything else → `owid-docs.pages.dev`

That's a separate piece of work once both projects are healthy on their pages.dev URLs.