### PR TITLE
🔨 Route /projects/owid-grapher-py/ through CF router

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -14,6 +14,7 @@
 
 const SUBPROJECTS = {
   "/projects/etl/": "https://owid-etl-docs.pages.dev",
+  "/projects/owid-grapher-py/": "https://owid-grapher-py-docs.pages.dev",
 };
 
 export default {


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Adds one entry to the `SUBPROJECTS` map in `_worker.js` so the umbrella custom domain proxies `/projects/owid-grapher-py/*` to the new `owid-grapher-py-docs` Pages project. Pairs with [owid/owid-grapher-py#26](https://github.com/owid/owid-grapher-py/pull/26).

Merge order: land owid-grapher-py#26 first (so the target Pages project exists), then this. Reverse order is also safe — only the owid-grapher-py path would 404 until the target project is up.