### PR TITLE
🔨 301 legacy /en/latest URLs to canonical paths

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -17,9 +17,19 @@ const SUBPROJECTS = {
   "/projects/owid-grapher-py/": "https://owid-grapher-py-docs.pages.dev",
 };
 
+// Legacy ReadTheDocs URLs include an /en/latest segment (e.g.
+// /projects/etl/en/latest/, /en/latest/). 301 to the canonical form so
+// existing inbound links from blog posts / Slack / bookmarks keep working.
+const RTD_LEGACY = /\/en\/latest(\/|$)/;
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
+
+    if (RTD_LEGACY.test(url.pathname)) {
+      url.pathname = url.pathname.replace(RTD_LEGACY, "$1") || "/";
+      return Response.redirect(url.toString(), 301);
+    }
 
     for (const [prefix, origin] of Object.entries(SUBPROJECTS)) {
       if (url.pathname.startsWith(prefix)) {


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Inbound links from blog posts, Slack threads, bookmarks etc. use the ReadTheDocs URL shape (`/en/latest/...`). Strip that segment in the umbrella `_worker.js` so those links keep resolving once `docs.owid.io` cuts over to CF.

| from | to |
|---|---|
| `/en/latest/` | `/` |
| `/projects/etl/en/latest/` | `/projects/etl/` |
| `/projects/etl/en/latest/anything.html` | `/projects/etl/anything.html` |
| `/projects/owid-grapher-py/en/latest/foo` | `/projects/owid-grapher-py/foo` |

Returns a 301 so search engines + browser caches converge on the canonical URL, then subproject routing happens on the rewritten path.