### PR TITLE
🐛 Redirect bare subproject roots (/projects/etl → /projects/etl/)

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -49,6 +49,14 @@ export default {
     }
 
     for (const [prefix, origin] of Object.entries(SUBPROJECTS)) {
+      // Bare project root without trailing slash (/projects/etl) — redirect
+      // to the canonical slash form, otherwise it falls through to the
+      // umbrella's static assets and 404s. Deeper slash-less paths don't
+      // need this: the proxied Pages project 308s them itself.
+      if (url.pathname === prefix.slice(0, -1)) {
+        url.pathname = prefix;
+        return Response.redirect(url.toString(), 301);
+      }
       if (url.pathname.startsWith(prefix)) {
         const target = `${origin}${url.pathname}${url.search}`;
         return fetch(target, request);


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Found right after the cut-over (owid/etl#6151): `docs.owid.io/projects/etl` (no trailing slash) 404s — the `SUBPROJECTS` match is `startsWith("/projects/etl/")`, so the bare root falls through to the umbrella's static assets. This also breaks legacy links like `/projects/etl/en/latest`, whose `/en/latest` strip 301s onto the bare root.

Fix: 301 the bare prefix to the slash form before the proxy match. Deeper slash-less paths are unaffected (the proxied Pages project already 308s those itself).

Verified pre-fix behavior:
```
404  /projects/etl
404  /projects/owid-grapher-py
301 → /projects/etl (→404)  /projects/etl/en/latest
308 → …/getting-started/    /projects/etl/getting-started  (already fine)
```